### PR TITLE
fix: avoid ONNX Runtime SIGBUS on 32-bit ARM by disabling graph optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.0.9
+
+* Fix native `SIGBUS` crash on 32-bit ARM (`armeabi-v7a`) when creating the ONNX Runtime session
+  - Native: Add `defaultGraphOptimizationLevel()`, which selects `ortDisableAll` on 32-bit platforms and keeps `ortEnableAll` everywhere else
+  - Native: Use it in `SileroV4Model.create` and `SileroV5Model.create` instead of the previously hard-coded `ortEnableAll`
+  - Cause: ONNX Runtime's `CommonSubexpressionElimination` pass hashes single-element tensor attributes by `reinterpret_cast`ing the protobuf `raw_data` pointer to `const float*` / `const int64_t*`. Those payloads start at arbitrary byte offsets, and on 32-bit ARM the VFP float load and the 64-bit `ldrd` both require natural alignment, so the process dies with `SIGBUS`/`BUS_ADRALN` inside `CreateSessionFromArray` (see microsoft/onnxruntime#26323)
+  - Scope: Affects both bundled models — `silero_vad_v5.onnx` has 263 misaligned single-element INT64 attributes, `silero_vad_legacy.onnx` has 3 misaligned FLOAT ones — so it could not be worked around by choosing a different model
+  - Diagnostics: Include `graphOpt=` in the `VadModel: creating OrtSession (...)` breadcrumb
+  - Fixes #21
+
 ## 0.0.8
 
 * Add `onLog` callback to `VadHandler.create` for routing production log lines to consumer-side telemetry (Crashlytics, Sentry, Bugsnag, etc.) without zone or `debugPrint` overrides

--- a/lib/src/platform/native/inference/silero_v4_model.dart
+++ b/lib/src/platform/native/inference/silero_v4_model.dart
@@ -13,6 +13,7 @@ import 'package:vad/src/core/vad_event.dart';
 import 'package:vad/src/core/vad_log.dart';
 import 'package:vad/src/core/vad_model.dart';
 import 'package:vad/src/utils/model_utils.dart';
+import 'package:vad/src/platform/native/onnxruntime/graph_optimization.dart';
 import 'package:vad/src/platform/native/onnxruntime/ort_session.dart';
 import 'package:vad/src/platform/native/onnxruntime/ort_value.dart';
 import 'package:vad/src/platform/native/onnxruntime/ort_threading_config.dart';
@@ -46,17 +47,19 @@ class SileroV4Model implements VadModel {
     final log = onLog ?? print;
     final config = threadingConfig ?? OrtThreadingConfig.platformOptimal();
     final bytes = await _loadModelBytes(modelPath);
+    final graphOptimizationLevel = defaultGraphOptimizationLevel();
     final context =
         'model=v4 path=$modelPath bytes=${bytes.length} sampleRate=$sampleRate '
         'intraOp=${config.intraOpNumThreads} interOp=${config.interOpNumThreads} '
-        'os=${Platform.operatingSystem} osVersion=${Platform.operatingSystemVersion}';
+        'os=${Platform.operatingSystem} osVersion=${Platform.operatingSystemVersion} '
+        'graphOpt=${graphOptimizationLevel.name}';
     log('VadModel: creating OrtSession ($context)');
 
     try {
       final sessionOptions = OrtSessionOptions()
         ..setInterOpNumThreads(config.interOpNumThreads)
         ..setIntraOpNumThreads(config.intraOpNumThreads)
-        ..setSessionGraphOptimizationLevel(GraphOptimizationLevel.ortEnableAll);
+        ..setSessionGraphOptimizationLevel(graphOptimizationLevel);
 
       final session = OrtSession.fromBuffer(bytes, sessionOptions);
 

--- a/lib/src/platform/native/inference/silero_v5_model.dart
+++ b/lib/src/platform/native/inference/silero_v5_model.dart
@@ -13,6 +13,7 @@ import 'package:vad/src/core/vad_event.dart';
 import 'package:vad/src/core/vad_log.dart';
 import 'package:vad/src/core/vad_model.dart';
 import 'package:vad/src/utils/model_utils.dart';
+import 'package:vad/src/platform/native/onnxruntime/graph_optimization.dart';
 import 'package:vad/src/platform/native/onnxruntime/ort_session.dart';
 import 'package:vad/src/platform/native/onnxruntime/ort_value.dart';
 import 'package:vad/src/platform/native/onnxruntime/ort_threading_config.dart';
@@ -44,17 +45,19 @@ class SileroV5Model implements VadModel {
     final log = onLog ?? print;
     final config = threadingConfig ?? OrtThreadingConfig.platformOptimal();
     final bytes = await _loadModelBytes(modelPath);
+    final graphOptimizationLevel = defaultGraphOptimizationLevel();
     final context =
         'model=v5 path=$modelPath bytes=${bytes.length} sampleRate=$sampleRate '
         'intraOp=${config.intraOpNumThreads} interOp=${config.interOpNumThreads} '
-        'os=${Platform.operatingSystem} osVersion=${Platform.operatingSystemVersion}';
+        'os=${Platform.operatingSystem} osVersion=${Platform.operatingSystemVersion} '
+        'graphOpt=${graphOptimizationLevel.name}';
     log('VadModel: creating OrtSession ($context)');
 
     try {
       final sessionOptions = OrtSessionOptions()
         ..setInterOpNumThreads(config.interOpNumThreads)
         ..setIntraOpNumThreads(config.intraOpNumThreads)
-        ..setSessionGraphOptimizationLevel(GraphOptimizationLevel.ortEnableAll);
+        ..setSessionGraphOptimizationLevel(graphOptimizationLevel);
 
       final session = OrtSession.fromBuffer(bytes, sessionOptions);
 

--- a/lib/src/platform/native/onnxruntime/graph_optimization.dart
+++ b/lib/src/platform/native/onnxruntime/graph_optimization.dart
@@ -1,0 +1,45 @@
+// lib/src/platform/native/onnxruntime/graph_optimization.dart
+// ignore_for_file: public_member_api_docs
+
+// Dart imports:
+import 'dart:ffi' as ffi;
+
+// Project imports:
+import 'package:vad/src/platform/native/onnxruntime/ort_session.dart';
+
+/// Graph optimization level to use for VAD inference sessions.
+///
+/// Returns [GraphOptimizationLevel.ortEnableAll] everywhere except 32-bit
+/// platforms, where it returns [GraphOptimizationLevel.ortDisableAll] to avoid a
+/// native crash inside ONNX Runtime.
+///
+/// ONNX Runtime's `CommonSubexpressionElimination` pass hashes single-element
+/// tensor attributes by casting the raw protobuf bytes directly to a typed
+/// pointer and dereferencing it:
+///
+/// ```cpp
+/// // onnxruntime/core/optimizer/common_subexpression_elimination.cc
+/// // GetTensorAttributeHash()
+/// UpdateHash(*reinterpret_cast<const float*>(attr_t.raw_data().data()), hash);
+/// UpdateHash(*reinterpret_cast<const int64_t*>(attr_t.raw_data().data()), hash);
+/// ```
+///
+/// A protobuf `raw_data` payload starts at an arbitrary byte offset, so those
+/// pointers are usually misaligned. 64-bit targets tolerate the loads; 32-bit
+/// ARM does not — the VFP float load and the 64-bit `ldrd` both require natural
+/// alignment — so the process dies with `SIGBUS` / `BUS_ADRALN` inside
+/// `CreateSessionFromArray`. Being a native signal, it cannot be caught from
+/// Dart or Java.
+///
+/// Both bundled models trigger this, so it cannot be avoided by model choice:
+/// `silero_vad_v5.onnx` holds 263 misaligned single-element INT64 attributes and
+/// `silero_vad_legacy.onnx` holds 3 misaligned FLOAT ones. Graph transformers
+/// only run at `Level1` and above, so disabling optimization skips the faulting
+/// pass entirely.
+///
+/// See https://github.com/microsoft/onnxruntime/issues/26323 and
+/// https://github.com/keyur2maru/vad/issues/21.
+GraphOptimizationLevel defaultGraphOptimizationLevel() =>
+    ffi.sizeOf<ffi.Pointer<ffi.Void>>() == 4
+        ? GraphOptimizationLevel.ortDisableAll
+        : GraphOptimizationLevel.ortEnableAll;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vad
 description: "VAD is a cross-platform Voice Activity Detection system, allowing Flutter applications to seamlessly handle various VAD events using Silero VAD v4/v5 models."
-version: 0.0.8
+version: 0.0.9
 repository: https://github.com/keyur2maru/vad
 issue_tracker: https://github.com/keyur2maru/vad/issues
 homepage: https://keyur2maru.github.io/vad/


### PR DESCRIPTION
Fixes #21.

`libonnxruntime.so` crashes with `SIGBUS` / `BUS_ADRALN` on 32-bit ARM (`armeabi-v7a`) while creating the inference session, killing the app at VAD start. It never happens on `arm64-v8a`. For our Android app this was 3,155 crash events across 1,249 users in 30 days — 51.7% of all our Android fatal crashes.

## Cause

Upstream ONNX Runtime bug, [microsoft/onnxruntime#26323](https://github.com/microsoft/onnxruntime/issues/26323). Its `CommonSubexpressionElimination` pass hashes single-element tensor attributes by casting the raw protobuf bytes straight to a typed pointer:

```cpp
// onnxruntime/core/optimizer/common_subexpression_elimination.cc — GetTensorAttributeHash()
if (utils::HasDataType(attr_t) && attr_t.dims_size() == 1 && attr_t.dims()[0] == 1 && utils::HasRawData(attr_t)) {
  case FLOAT: UpdateHash(*reinterpret_cast<const float*>(attr_t.raw_data().data()), hash);
  case INT64: UpdateHash(*reinterpret_cast<const int64_t*>(attr_t.raw_data().data()), hash);
```

A protobuf `raw_data` payload begins at an arbitrary byte offset, so those pointers are usually misaligned. 64-bit targets tolerate the loads; ARMv7 does not — the VFP float load and the 64-bit `ldrd` both require natural alignment. The signal kills the process before any Dart or Java code can react.

The reported `OrtSessionOptionsAppendExecutionProvider_Nnapi` frames are misleading: `libonnxruntime.so` is stripped, so tooling reports the nearest exported symbol. NNAPI is not involved.

## Both models are affected

Parsing both ONNX files for attributes matching ORT's exact guard (`dims == [1]` plus `raw_data`) and computing each payload's alignment:

| model | attrs matching the guard | misaligned → faults |
|---|---|---|
| `silero_vad_v5.onnx` | 296 (292 INT64) | **263** INT64, 8-byte misaligned → `ldrd` |
| `silero_vad_legacy.onnx` | 4 (all FLOAT) | **3** FLOAT, 4-byte misaligned → VFP load |

So this is not avoidable by choosing a model — v4 crashes too, in the FLOAT branch of the same `switch` rather than the INT64 one.

## Change

Graph transformers only run at `Level1` and above, so `ortDisableAll` skips the faulting pass. This PR adds `defaultGraphOptimizationLevel()`, returning `ortDisableAll` when `sizeOf<Pointer>() == 4` and `ortEnableAll` otherwise, and uses it in `SileroV4Model.create` and `SileroV5Model.create` in place of the hard-coded `ortEnableAll`. It also adds `graphOpt=` to the existing `creating OrtSession` breadcrumb, which is what let me confirm the selection on device.

## Verification

OnePlus 6 / Android 11, 32-bit-only build (`--split-per-abi --target-platform=android-arm`, `primaryCpuAbi=armeabi-v7a` confirmed via `pm dump`). 100% reproducible before, and the two crash sites are 52 bytes apart in the same function, matching the `FLOAT`/`FLOAT16`/`INT64` case order:

| `GraphOptimizationLevel` | v5 | v4 |
|---|---|---|
| `ortEnableAll` (before) | 💥 SIGBUS, leaf PC `…1322` | 💥 SIGBUS, leaf PC `…12ee` |
| `ortDisableAll` | ✅ | ✅ |

With this PR applied and no manual override, the level in each row was chosen by the new code:

| build | level it selected | result |
|---|---|---|
| `armeabi-v7a`, v5 | `ortDisableAll` | ✅ initialised and ran |
| `armeabi-v7a`, v4 | `ortDisableAll` | ✅ initialised and ran |
| `arm64-v8a`, v5 | `ortEnableAll` | ✅ initialised and ran — 64-bit unchanged |

`dart format` and `flutter analyze` are clean on Flutter 3.41.6.

## Two things for your call

1. **I gated on 32-bit generally, not ARM specifically.** The cast is UB everywhere but only architecturally fatal on ARM32, and losing one optimizer pass on a ~2 MB model seemed like cheap insurance. Happy to narrow to `Abi.androidArm` / `Abi.iosArm` / `Abi.linuxArm` if you'd rather leave 32-bit x86 alone.
2. **A narrower fix may exist:** `optimization.disable_specified_optimizers=CommonSubexpressionElimination` via `AddSessionConfigEntry`, keeping the other passes. That needs a new FFI binding, and I have not verified CSE is the *only* pass doing unaligned reads, so I went with the option I could verify on hardware.

I also bumped the version and added a CHANGELOG entry — happy to drop those if you'd rather own releases. And I have a reliable 32-bit repro set up, so I'm glad to run further experiments if that would help.
